### PR TITLE
JSX配列を作成しJSX内に展開

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,21 +57,100 @@ class Summary extends React.Component {
 }
 
 class AdmissionFeeCalculator extends React.Component {
-  private detail: DetailProps = {
-    classification:{
-      name: "所得割課税額397,000円以上",
-      description: "",
-      unitPrice: 104000,
-      numOfPeople: 0,
-      totalPrice: 0
-    }
-  };
+  private details: DetailProps[] = [
+    {
+      classification:{
+        name: "年収1,130万円以上",
+        description: "",
+        unitPrice: 104000,
+        numOfPeople: 0,
+        totalPrice: 0
+      }
+    },
+    {
+      classification:{
+        name: "年収1,130万円未満",
+        description: "",
+        unitPrice: 80000,
+        numOfPeople: 0,
+        totalPrice: 0
+      }
+    },
+    {
+      classification:{
+        name: "年収930万円未満",
+        description: "",
+        unitPrice: 61000,
+        numOfPeople: 0,
+        totalPrice: 0
+      }
+    },
+    {
+      classification:{
+        name: "年収640万円未満",
+        description: "",
+        unitPrice: 44500,
+        numOfPeople: 0,
+        totalPrice: 0
+      }
+    },
+    {
+      classification:{
+        name: "年収470万円未満",
+        description: "",
+        unitPrice: 30000,
+        numOfPeople: 0,
+        totalPrice: 0
+      }
+    },
+    {
+      classification:{
+        name: "年収360万円未満",
+        description: "",
+        unitPrice: 30000,
+        numOfPeople: 0,
+        totalPrice: 0
+      }
+    },
+    {
+      classification:{
+        name: "年収330万円未満",
+        description: "",
+        unitPrice: 19500,
+        numOfPeople: 0,
+        totalPrice: 0
+      }
+    },
+    {
+      classification:{
+        name: "年収260万円未満",
+        description: "",
+        unitPrice: 9000,
+        numOfPeople: 0,
+        totalPrice: 0
+      }
+    },
+    {
+      classification:{
+        name: "生活保護世帯",
+        description: "",
+        unitPrice: 0,
+        numOfPeople: 0,
+        totalPrice: 0
+      }
+    },
+  ];
 
   //親コンポーネントにあたるAdmissionFeeCalculatorでは、Detailコンポーネントにプロパティを渡す必要があります。
   render() {
+    const detailsJsx = this.details.map((fc, idx) => {
+      return (
+        <Detail key ={idx.toString()} classification={fc.classification} />
+      );
+    });
     return (
       <>
-        <Detail classification={this.detail.classification}/>
+        {detailsJsx}
         <Summary />
       </>
     );


### PR DESCRIPTION
renderメソッドでは、まずは複数行の明細を表すJSX（の配列）を作成します。
コードサンプルでは配列のmapメソッドを使ってJSX要素の配列へ変換しています。定数detailsJsxの実際の型はJSX.Element[]となります。

ここで注意すべき点は、**繰り返し表示するコンポーネントに対してはkey属性を付与する必要がある**ということです。
これは、繰り返し表示する対象のモデルに変更が加えられたときに、変更が発生したアイテムを特定するために必要な識別子です。
key属性には、アイテムを特定可能な任意の値をセットします。今回のサンプルはアイテムの入れ替りは発生しないので、単純にインデックスをキーとしています。

あとは本体のJSX内に明細のJSX配列を展開（{detailJsx}の部分）するだけです。

